### PR TITLE
Updade v1.7.2

### DIFF
--- a/org.openttd.openttd.json
+++ b/org.openttd.openttd.json
@@ -1,8 +1,8 @@
 {
   "app-id": "org.openttd.openttd",
-  "version": "1.7.1-RC1",
+  "version": "1.7.2",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "1.4",
+  "runtime-version": "1.6",
   "sdk": "org.freedesktop.Sdk",
   "command": "openttd",
   "rename-desktop-file": "openttd.desktop",
@@ -40,8 +40,8 @@
           "sources" : [
               {
                   "type": "archive",
-                  "url": "https://binaries.openttd.org/releases/1.7.1/openttd-1.7.1-source.tar.xz",
-		  "sha256": "61190952a98d494d3fd62e395dd6c359609914d0ba8fe80eaeb585b7d62a1b36"
+                  "url": "http://ftp.snt.utwente.nl/pub/games/openttd/binaries/releases/1.7.2/openttd-1.7.2-source.tar.gz",
+		  "sha256": "a60580bc4e4c35ca057ee1ffb9d113b4d2151643e8830e01952cc8f7f19a96ae"
               }
           ]
       },


### PR DESCRIPTION
1.7.2 (2017-12-24)
------------------------------------------------------------------------
(None)


1.7.2-RC1 (2017-12-11)
------------------------------------------------------------------------
- Change: When train depots have a horizontal scrollbar, allow scrolling 1 tile beyond the longest train, so you can actually attach a wagon at the end (r27937)
- Fix: When moving wagons in the depot, the drag highlight did not exactly match the length of the dragged wagon chain (r27936)
- Fix: [Win32] Right mouse scrolling didn't work properly with the Windows 10 Fall Creators Update [FS#6629] (r27935)
- Fix: Forest, candyfloss forest and battery farm skipped the first animation frame [FS#6639] (r27932)
- Fix: Glyphs in range U+0020 to U+00FF may only be defined in orig_extra.grf, not in openttd.grf [FS#6620] (r27915)
- Fix: 'unban' console command was not handling IPv6 adresses properly (r27914, r27913)
- Fix: Keep the 'link' between industry chain and smallmap windows whenever possible [FS#6585] (r27905)
- Fix: When the last vehicle is removed from a shared orders group, hide the 'Stop sharing' button in the vehicle orders window [FS#6593] (r27904)
- Fix: Tooltip of 'increase service interval' said 'decrease' [FS#6606] (r27895)
- Fix: Console command parser passed invalid strings to the debug output, if command lines had many parameters [FS#6576] (r27884, r27883)

